### PR TITLE
Added $id as parameter to template tag

### DIFF
--- a/dot-irecommendthis.php
+++ b/dot-irecommendthis.php
@@ -846,10 +846,10 @@ if ( ! class_exists( 'DOT_IRecommendThis' ) )
 	 * Template Tag
 	 *--------------------------------------------*/
 
-	function dot_irecommendthis()
+	function dot_irecommendthis( $id = null )
 	{
 		global $dot_irecommendthis;
-		echo $dot_irecommendthis->dot_recommend();
+		echo $dot_irecommendthis->dot_recommend( $id );
 
 	}
 


### PR DESCRIPTION
The method `dot_recommend()` accepts a POST ID but the template tag didn't.
