### PR TITLE
Fix template tag

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -8,7 +8,7 @@
 
 function dot_irecommendthis($id = null)
 {
-	global $dot_irecommendthis;
-	echo $dot_irecommendthis->dot_recommend($id);
+	global $themeist_i_recommend_this_public;
+	echo $themeist_i_recommend_this_public->dot_recommend($id);
 
 }


### PR DESCRIPTION
When the global variable holding an instance of the public class was updated, this was not. Version 3.8.2 breaks sites with a fatal error because of this.