### PR TITLE
Rest api likes

### DIFF
--- a/core/class-themeist-irecommendthis-rest.php
+++ b/core/class-themeist-irecommendthis-rest.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * REST API integration for I Recommend This.
+ *
+ * @package IRecommendThis
+ * @subpackage Core
+ */
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Registers REST fields and routes for recommendations.
+ *
+ * @since 4.1.0
+ */
+class Themeist_IRecommendThis_Rest {
+
+	/**
+	 * REST API namespace (versioned).
+	 *
+	 * @var string
+	 */
+	const NAMESPACE_V1 = 'irecommendthis/v1';
+
+	/**
+	 * Hook into WordPress.
+	 */
+	public function initialize() {
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes_and_fields' ) );
+	}
+
+	/**
+	 * Register REST routes and the post like-count field.
+	 */
+	public function register_rest_routes_and_fields() {
+		$post_types = $this->get_rest_post_types();
+
+		foreach ( $post_types as $post_type ) {
+			register_rest_field(
+				$post_type,
+				'irt_likes',
+				array(
+					'get_callback'    => array( $this, 'get_post_like_count_for_rest' ),
+					'schema'       => array(
+						'description' => __( 'Number of recommendations (likes) for this post.', 'i-recommend-this' ),
+						'type'        => 'integer',
+						'readonly'    => true,
+						'context'     => array( 'view', 'edit', 'embed' ),
+					),
+				)
+			);
+		}
+
+		register_rest_route(
+			self::NAMESPACE_V1,
+			'/posts/(?P<id>\d+)/like',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'like_post' ),
+				'permission_callback' => array( $this, 'like_permission' ),
+				'args'                => array(
+					'id'          => array(
+						'description' => __( 'Unique identifier for the post.', 'i-recommend-this' ),
+						'type'        => 'integer',
+						'required'    => true,
+					),
+					'unrecommend' => array(
+						'description' => __( 'If true, unlike the post (matches AJAX behaviour).', 'i-recommend-this' ),
+						'type'        => array( 'string', 'boolean' ),
+						'default'     => false,
+					),
+				),
+			)
+		);
+
+		/**
+		 * Fires after REST routes and fields for I Recommend This are registered.
+		 *
+		 * @since 4.1.0
+		 */
+		do_action( 'irecommendthis_rest_registered' );
+	}
+
+	/**
+	 * Resolve post types that expose the `irt_likes` REST field.
+	 *
+	 * @return string[]
+	 */
+	private function get_rest_post_types() {
+		/**
+		 * Filter which post types include the `irt_likes` REST field.
+		 *
+		 * @since 4.1.0
+		 * @param string[] $post_types Post type names. Default `post` only.
+		 */
+		$post_types = apply_filters( 'irecommendthis_rest_post_types', array( 'post' ) );
+		$post_types = array_filter( array_map( 'sanitize_key', (array) $post_types ) );
+
+		$valid = array();
+		foreach ( $post_types as $post_type ) {
+			if ( post_type_exists( $post_type ) ) {
+				$valid[] = $post_type;
+			}
+		}
+
+		if ( empty( $valid ) && post_type_exists( 'post' ) ) {
+			$valid[] = 'post';
+		}
+
+		return $valid;
+	}
+
+	/**
+	 * REST callback: integer like count from `_recommended` meta.
+	 *
+	 * @param array $object Post REST field object.
+	 * @return int
+	 */
+	public function get_post_like_count_for_rest( $object ) {
+		$post_id = isset( $object['id'] ) ? (int) $object['id'] : 0;
+		if ( $post_id <= 0 ) {
+			return 0;
+		}
+
+		$meta = get_post_meta( $post_id, '_recommended', true );
+		if ( '' === $meta || false === $meta ) {
+			return 0;
+		}
+
+		return (int) $meta;
+	}
+
+	/**
+	 * Permission check for POST like route.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return bool|\WP_Error
+	 */
+	public function like_permission( $request ) {
+		$post_id = (int) $request->get_param( 'id' );
+		$post    = $post_id > 0 ? get_post( $post_id ) : null;
+
+		/**
+		 * Override permission for the REST like endpoint.
+		 *
+		 * Return null to use the default rules. Return true/false, or a WP_Error.
+		 *
+		 * @since 4.1.0
+		 * @param null|bool|\WP_Error $permission Current decision. Default null (use plugin defaults).
+		 * @param \WP_REST_Request    $request    Request object.
+		 * @param \WP_Post|null       $post       Post object if the ID exists, else null.
+		 */
+		$filtered = apply_filters( 'irecommendthis_rest_like_permission', null, $request, $post );
+		if ( null !== $filtered ) {
+			if ( is_wp_error( $filtered ) ) {
+				return $filtered;
+			}
+			return (bool) $filtered;
+		}
+
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to recommend posts via the REST API.', 'i-recommend-this' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		if ( ! $post ) {
+			return true;
+		}
+
+		$allowed_types = apply_filters( 'irecommendthis_rest_post_types', array( 'post' ) );
+		$allowed_types = array_map( 'sanitize_key', (array) $allowed_types );
+		if ( ! in_array( $post->post_type, $allowed_types, true ) ) {
+			return new WP_Error(
+				'rest_invalid_post_type',
+				__( 'Recommendations are not enabled for this post type.', 'i-recommend-this' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( 'publish' !== $post->post_status ) {
+			return new WP_Error(
+				'rest_post_not_published',
+				__( 'Only published posts can be recommended via the REST API.', 'i-recommend-this' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( ! current_user_can( 'read_post', $post_id ) ) {
+			return new WP_Error(
+				'rest_cannot_read_post',
+				__( 'Sorry, you are not allowed to recommend this post.', 'i-recommend-this' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * POST handler: process recommendation using the same processor as AJAX.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function like_post( $request ) {
+		$post_id = (int) $request->get_param( 'id' );
+
+		/**
+		 * Filter the post ID before processing (parity with AJAX).
+		 *
+		 * @since 4.0.0
+		 * @param int $post_id The post ID.
+		 */
+		$post_id = (int) apply_filters( 'irecommendthis_ajax_post_id', $post_id );
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid post ID.', 'i-recommend-this' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$allowed_types = apply_filters( 'irecommendthis_rest_post_types', array( 'post' ) );
+		$allowed_types = array_map( 'sanitize_key', (array) $allowed_types );
+		if ( ! in_array( $post->post_type, $allowed_types, true ) ) {
+			return new WP_Error(
+				'rest_invalid_post_type',
+				__( 'Recommendations are not enabled for this post type.', 'i-recommend-this' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( 'publish' !== $post->post_status ) {
+			return new WP_Error(
+				'rest_post_not_published',
+				__( 'Only published posts can be recommended via the REST API.', 'i-recommend-this' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$unrecommend = $this->parse_unrecommend_param( $request );
+
+		$options          = get_option( 'irecommendthis_settings' );
+		$text_zero_suffix = isset( $options['text_zero_suffix'] ) ? sanitize_text_field( $options['text_zero_suffix'] ) : '';
+		$text_one_suffix  = isset( $options['text_one_suffix'] ) ? sanitize_text_field( $options['text_one_suffix'] ) : '';
+		$text_more_suffix = isset( $options['text_more_suffix'] ) ? sanitize_text_field( $options['text_more_suffix'] ) : '';
+
+		Themeist_IRecommendThis_Public_Processor::process_recommendation(
+			$post_id,
+			$text_zero_suffix,
+			$text_one_suffix,
+			$text_more_suffix,
+			'update',
+			$unrecommend
+		);
+
+		$likes = (int) get_post_meta( $post_id, '_recommended', true );
+
+		$data = array(
+			'post_id' => $post_id,
+			'likes'   => $likes,
+			'message' => __( 'Recommendation updated.', 'i-recommend-this' ),
+		);
+
+		/**
+		 * Filter the REST JSON response for a successful like/unlike request.
+		 *
+		 * @since 4.1.0
+		 * @param array           $data    Response data.
+		 * @param int             $post_id Post ID.
+		 * @param \WP_REST_Request $request Request object.
+		 */
+		$data = apply_filters( 'irecommendthis_rest_like_response', $data, $post_id, $request );
+
+		return new WP_REST_Response( $data, 200 );
+	}
+
+	/**
+	 * Normalize unrecommend from JSON body, query string, or default.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return string `'true'` or `'false'`.
+	 */
+	private function parse_unrecommend_param( $request ) {
+		$raw = $request->get_param( 'unrecommend' );
+
+		if ( true === $raw || false === $raw ) {
+			return true === $raw ? 'true' : 'false';
+		}
+
+		$str = strtolower( sanitize_text_field( (string) $raw ) );
+		if ( '' === $str ) {
+			return 'false';
+		}
+
+		return ( 'true' === $str || '1' === $str ) ? 'true' : 'false';
+	}
+}

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -137,6 +137,24 @@ The plugin provides extensive hooks and filters for customization.
 | `irecommendthis_after_ajax_process` | Fired after processing AJAX recommendation request | `$post_id`, `$result`, `$_POST` |
 | `irecommendthis_ajax_response` | Filter the AJAX response HTML | `$result`, `$post_id` |
 
+### REST API Hooks
+
+**Fields & registration**
+
+| Hook | Description | Parameters |
+|------|-------------|------------|
+| `irecommendthis_rest_post_types` | Post types that expose the `irt_likes` REST field and are allowed for the like route | Array of post type strings (default `post` only) |
+| `irecommendthis_rest_registered` | Fired after REST routes and fields are registered | None |
+
+**Like endpoint (`POST /wp-json/irecommendthis/v1/posts/{id}/like`)**
+
+| Hook | Description | Parameters |
+|------|-------------|------------|
+| `irecommendthis_rest_like_permission` | Override permission: return `null` for default rules, or `true` / `false` / `WP_Error` | `$permission` (null), `$request` (`WP_REST_Request`), `$post` (`WP_Post` or null) |
+| `irecommendthis_rest_like_response` | Filter successful JSON (`post_id`, `likes`, `message`) | `$data` (array), `$post_id`, `$request` |
+
+Default permission requires a logged-in user who may **read** the post (`read_post`), the post must be **published**, and its type must be allowed by `irecommendthis_rest_post_types`. Unauthenticated requests receive a REST authentication error (status from `rest_authorization_required_code()`). Use [Application Passwords](https://make.wordpress.org/core/2020/11/05/application-passwords-integration-guide/) over HTTPS for mobile and headless clients.
+
 ### Shortcode Hooks
 
 | Hook | Description | Parameters |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,6 +13,7 @@
 - Gutenberg block integration for modern WordPress sites
 - GDPR compliance options including IP anonymization
 - Extensive developer hooks for customization
+- REST API: `irt_likes` on core post REST responses and an authenticated `POST .../irecommendthis/v1/posts/{id}/like` endpoint (for headless/mobile clients; see developer docs)
 
 ## File Structure
 
@@ -48,6 +49,7 @@ i-recommend-this/
 ├── core/                                 # Core functionality
 │   ├── class-themeist-irecommendthis.php              # Main plugin class
 │   ├── class-themeist-irecommendthis-ajax.php         # AJAX processing
+│   ├── class-themeist-irecommendthis-rest.php         # REST API fields and routes
 │   ├── class-themeist-irecommendthis-db-upgrader.php  # Database management
 │   ├── class-themeist-irecommendthis-shortcodes.php   # Shortcodes
 │   ├── functions.php                                  # Public functions
@@ -95,6 +97,11 @@ Each component focuses on a specific functionality:
    - Processes recommendation requests
    - Validates security nonces
    - Returns updated recommendation counts
+
+6. **REST API** (`Themeist_IRecommendThis_Rest`)
+   - Registers the `irt_likes` field on allowed post types in `wp/v2` responses
+   - Exposes `POST /wp-json/irecommendthis/v1/posts/{id}/like` for authenticated clients
+   - Reuses the same recommendation processor as AJAX (cookie/IP rules apply)
 
 ## Database Structure
 
@@ -153,3 +160,7 @@ The recommendation process follows this workflow:
    - `irecommendthis_after_process_recommendation` action fires
    - Cache clearing functions can be triggered for the specific post
    - Ensures visitors see updated recommendation counts even with caching
+
+### REST API path (headless / mobile)
+
+For authenticated HTTP clients (e.g. Application Passwords over HTTPS): **read** the like count via `GET /wp-json/wp/v2/posts` or a single post (`irt_likes`). **Write** a like or unlike using `POST /wp-json/irecommendthis/v1/posts/{id}/like`, optionally with `unrecommend=true` (same semantics as AJAX). Server-side logic matches the AJAX flow; details and hooks are in `docs/developers.md` and `docs/technical-reference.md`.

--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -120,6 +120,26 @@ Handles AJAX processing for the plugin.
 - `add_ajax_hooks()`: Registers AJAX hooks
 - `ajax_callback()`: Processes AJAX recommendation requests
 
+#### `Themeist_IRecommendThis_Rest`
+
+Registers REST API fields and routes (since 4.1.0).
+
+**Key Methods:**
+- `initialize()`: Hooks `rest_api_init`
+- `register_rest_routes_and_fields()`: Registers `irt_likes` on allowed post types and the like route
+- `get_post_like_count_for_rest()`: REST field callback reading `_recommended` meta
+- `like_permission()`: Permission callback for `POST .../like`
+- `like_post()`: Runs `Themeist_IRecommendThis_Public_Processor::process_recommendation()` with the same settings suffixes as AJAX
+
+**REST surface**
+
+| Item | Details |
+|------|---------|
+| Like count field | Name `irt_likes` (integer), on each post object from `GET /wp/v2/posts` and `GET /wp/v2/posts/{id}` when the post type is allowed |
+| Like route | `POST /wp-json/irecommendthis/v1/posts/{id}/like` |
+| Body / query | Optional `unrecommend`: `true` or `false` (string or boolean in JSON), same meaning as the AJAX parameter |
+| Auth | Authenticated WordPress user by default (e.g. Basic auth with an Application Password). Not intended for anonymous writing |
+
 ### Admin Classes
 
 #### `Themeist_IRecommendThis_Admin`

--- a/i-recommend-this.php
+++ b/i-recommend-this.php
@@ -3,7 +3,7 @@
  * Plugin Name: I Recommend This
  * Plugin URI: https://themeist.com/plugins/wordpress/i-recommend-this/#utm_source=wp-plugin&utm_medium=i-recommend-this&utm_campaign=plugins-page
  * Description: This plugin allows your visitors to recommend or like your posts.
- * Version: 4.0.1
+ * Version: 4.1.0
  * Author: Themeist
  * Author URI: https://themeist.com/
  * Author Email: support@themeist.com/
@@ -24,7 +24,7 @@ if ( class_exists( 'Themeist_IRecommendThis' ) ) {
 	return;
 }
 
-define( 'THEMEIST_IRT_VERSION', '4.0.1' );
+define( 'THEMEIST_IRT_VERSION', '4.1.0' );
 define( 'THEMEIST_IRT_DB_VERSION', '3.0.0' );
 
 // Require includes.
@@ -34,6 +34,7 @@ require_once __DIR__ . '/admin/class-themeist-irecommendthis-admin.php';
 require_once __DIR__ . '/public/class-themeist-irecommendthis-public.php';
 require_once __DIR__ . '/public/class-themeist-irecommendthis-widget-most-recommended.php';
 require_once __DIR__ . '/core/class-themeist-irecommendthis-ajax.php';
+require_once __DIR__ . '/core/class-themeist-irecommendthis-rest.php';
 require_once __DIR__ . '/core/class-themeist-irecommendthis-shortcodes.php';
 require_once __DIR__ . '/core/functions.php';
 require_once __DIR__ . '/blocks/blocks.php';
@@ -57,6 +58,10 @@ $themeist_i_recommend_this_public->add_public_hooks();
 global $themeist_i_recommend_this_ajax;
 $themeist_i_recommend_this_ajax = new Themeist_IRecommendThis_Ajax();
 $themeist_i_recommend_this_ajax->add_ajax_hooks();
+
+global $themeist_i_recommend_this_rest;
+$themeist_i_recommend_this_rest = new Themeist_IRecommendThis_Rest();
+$themeist_i_recommend_this_rest->initialize();
 
 add_action( 'init', 'themeist_register_shortcodes' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://themeist.com/plugins/wordpress/i-recommend-this/
 Tags: like, love, post, rate, recommend
 Requires at least: 6.1
 Tested up to: 6.8
-Stable tag: 4.0.1
+Stable tag: 4.1.0
 Requires PHP: 7.4
 License: GPL-3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
@@ -25,6 +25,7 @@ Enable your visitors to easily like or recommend your posts with a single click,
 - Better GDPR compliance with anonymized IPs
 - Built-in query block compatibility
 - Extensive action and filter hooks for developers
+- REST API: read like counts on `wp/v2/posts` (`irt_likes` field) and recommend published posts via `POST /wp-json/irecommendthis/v1/posts/{id}/like` (authenticated; Application Passwords supported — use HTTPS)
 
 
 ### Advanced Options:
@@ -148,6 +149,9 @@ Please report security bugs found in the source code through the [Patchstack Vul
 IMPORTANT: After upgrading, run "Optimize Database" in Settings > DB Tools. Update custom CSS to target .irecommendthis-wrapper. Template tags and shortcodes changed from dot_irecommendthis to irecommendthis. Legacy code still works for backward compatibility.
 
 == Changelog ==
+
+= 4.1.0 =
+* Added REST API support: `irt_likes` field on post objects in `GET /wp/v2/posts` (and single post), and `POST /wp-json/irecommendthis/v1/posts/{id}/like` for authenticated clients (e.g. Application Passwords). Cookie and IP duplicate rules apply as on the front end. Developer filters documented in `docs/developers.md`.
 
 = 4.0.1 - (10 APril 2025) =
 * Updated translation template (.pot) using WP-CLI


### PR DESCRIPTION
Add a dedicated REST class that:

- Exposes the like count as irt_likes on post objects in the core Posts API
- Adds POST /irecommendthis/v1/posts/{id}/like for logged-in users (for example
  using an application password), using the same like and unlike rules as the
  rest of the plugin
- Accepts unrecommend (true/false) on that route when the client wants to unlike,
  matching the AJAX behaviour
- Uses the same post-type allow list and permission filters documented for
  developers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new authenticated write-capable REST endpoint and permission logic, which can affect access control and abuse surface if misconfigured via filters. Changes are otherwise additive and reuse existing recommendation processing rules.
> 
> **Overview**
> Adds REST API support via new `Themeist_IRecommendThis_Rest`: exposes an `irt_likes` field on allowed post types’ `wp/v2` responses and introduces `POST /wp-json/irecommendthis/v1/posts/{id}/like` to like/unlike (via `unrecommend`) using the same processor and settings suffixes as AJAX.
> 
> Wires the REST component into plugin bootstrap (`i-recommend-this.php`), bumps plugin version to `4.1.0`, and updates docs/readme with the new REST surface plus developer hooks (`irecommendthis_rest_post_types`, `irecommendthis_rest_like_permission`, `irecommendthis_rest_like_response`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b5e62f64f4b6c6d7d06ba83eb2261c85e27f2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->